### PR TITLE
Added more UUIDs and better UUID descriptions. Fixes issue #5

### DIFF
--- a/XLCXcodeAssist.xcodeproj/xcshareddata/xcschemes/XLCXcodeAssist.xcscheme
+++ b/XLCXcodeAssist.xcodeproj/xcshareddata/xcschemes/XLCXcodeAssist.xcscheme
@@ -38,6 +38,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      viewDebuggingEnabled = "NO"
       allowLocationSimulation = "YES">
       <PathRunnable
          FilePath = "/Applications/Xcode.app">

--- a/XLCXcodeAssist/XLCXcodeAssist-Info.plist
+++ b/XLCXcodeAssist/XLCXcodeAssist-Info.plist
@@ -31,14 +31,25 @@
 	<string>1.0</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
-		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
-		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
-		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
-		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
-        <string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
-        <string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
-        <string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
-        <string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+        <string>37B30044-3B14-46BA-ABAA-F01000C27B63</string> <!-- 5.0      -->
+        <string>640F884E-CE55-4B40-87C0-8869546CAB7A</string> <!-- 5.1 DP   -->
+        <string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string> <!-- 5.1      -->
+        <string>AD68E85B-441B-4301-B564-A45E4919A6AD</string> <!-- 6.0 Beta -->
+        <string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string> <!-- 6.0 GM   -->
+        <string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string> <!-- 6.2 Beta -->
+        <string>A16FF353-8441-459E-A50C-B071F53F51B7</string> <!-- 6.2      -->
+        <string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string> <!-- 6.3 Beta -->
+        <string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string> <!-- 6.3      -->
+        <string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string> <!-- 6.3.2    -->
+        <string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string> <!-- 6.4 Beta -->
+        <string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string> <!-- 6.4 B4   -->
+        <string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string> <!-- 6.4      -->
+        <string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string> <!-- 7.0 Beta -->
+        <string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string> <!-- 7.0 GM   -->
+        <string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string> <!-- 7.1 Beta -->
+        <string>7265231C-39B4-402C-89E1-16167C4CC990</string> <!-- 7.1      -->
+        <string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string> <!-- 7.2 Beta -->
+        <string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string> <!-- 7.2      -->
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>XLCXcodeAssist</string>


### PR DESCRIPTION
Added viewDebuggingEnabled = NO and better descriptions + additional UUIDs in the info.plist. This fixes the problem with the plugin not installing in xcode 7.2.